### PR TITLE
Hot fix: updated Earth Engine authentication and map tile url calls

### DIFF
--- a/tethysapp/waterwatch/ajax_controllers.py
+++ b/tethysapp/waterwatch/ajax_controllers.py
@@ -63,10 +63,8 @@ def mndwi(request):
 
         try:
             true_img,mndwi_img,properties = getMNDWI(lon,lat,x_val,y_val)
-            return_obj["water_mapid"] = mndwi_img["mapid"]
-            return_obj["water_token"] = mndwi_img["token"]
-            return_obj["true_mapid"] = true_img["mapid"]
-            return_obj["true_token"] = true_img["token"]
+	    return_obj['water_mapurl'] = mndwi_img['tile_fetcher'].url_format
+            return_obj['true_mapurl'] = true_img['tile_fetcher'].url_format
             return_obj["date"] = clicked_date
             return_obj["cloud_cover"] = properties["CLOUD_COVER"]
             return_obj["success"] = "success"

--- a/tethysapp/waterwatch/ajax_controllers.py
+++ b/tethysapp/waterwatch/ajax_controllers.py
@@ -62,9 +62,11 @@ def mndwi(request):
         lon = info.get('lon')
 
         try:
-            mndwi_img,properties = getMNDWI(lon,lat,x_val,y_val)
+            true_img,mndwi_img,properties = getMNDWI(lon,lat,x_val,y_val)
             return_obj["water_mapid"] = mndwi_img["mapid"]
             return_obj["water_token"] = mndwi_img["token"]
+            return_obj["true_mapid"] = true_img["mapid"]
+            return_obj["true_token"] = true_img["token"]
             return_obj["date"] = clicked_date
             return_obj["cloud_cover"] = properties["CLOUD_COVER"]
             return_obj["success"] = "success"

--- a/tethysapp/waterwatch/config.py
+++ b/tethysapp/waterwatch/config.py
@@ -1,0 +1,2 @@
+EE_SERVICE_ACCOUNT = '<service account email>'
+EE_SECRET_KEY = '<secret key path>'

--- a/tethysapp/waterwatch/controllers.py
+++ b/tethysapp/waterwatch/controllers.py
@@ -10,8 +10,7 @@ def home(request):
     ponds = initLayers()
 
     context = {
-        'ponds_mapid':ponds['mapid'],
-        'ponds_token':ponds['token']
+	'ponds_mapurl':ponds['tile_fetcher'].url_format
     }
 
     return render(request, 'waterwatch/home.html', context)

--- a/tethysapp/waterwatch/public/js/map.js
+++ b/tethysapp/waterwatch/public/js/map.js
@@ -28,7 +28,9 @@ var LIBRARY_OBJECT = (function() {
         select_feature_layer,
         $chartModal,
         water_source,
-        water_layer;
+        water_layer,
+        true_source,
+        true_layer;
 
 
 
@@ -122,7 +124,13 @@ var LIBRARY_OBJECT = (function() {
             // url:""
         });
 
-        layers = [base_map,base_map2,ponds_layer,water_layer,boundary_layer,select_feature_layer];
+        true_source = new ol.source.XYZ();
+        true_layer = new ol.layer.Tile({
+            source: true_source
+            // url:""
+        });
+
+        layers = [base_map,base_map2,ponds_layer,true_layer,water_layer,boundary_layer,select_feature_layer];
         map = new ol.Map({
             target: 'map',
             layers: layers,
@@ -158,7 +166,7 @@ var LIBRARY_OBJECT = (function() {
         //Map on zoom function. To keep track of the zoom level. Data can only be viewed can only be added at a certain zoom level.
         map.on("moveend", function() {
             var zoom = map.getView().getZoom();
-            var zoomInfo = '<p style="color:white;">Current Zoom level = ' + parseFloat(zoom,3)+'.</p>';
+            var zoomInfo = '<p style="color:white;">Current Zoom level = ' + zoom.toFixed(3)+'.</p>';
             document.getElementById('zoomlevel').innerHTML = zoomInfo;
             if (zoom > 14){
                 base_map2.setVisible(true);
@@ -201,6 +209,7 @@ var LIBRARY_OBJECT = (function() {
                 if("success" in data) {
                     $('.info').html('');
                     map.getLayers().item(3).getSource().setUrl("");
+                    map.getLayers().item(4).getSource().setUrl("");
                     var polygon = new ol.geom.Polygon(data.coordinates);
                     polygon.applyTransform(ol.proj.getTransform('EPSG:4326', 'EPSG:3857'));
                     var feature = new ol.Feature(polygon);
@@ -287,7 +296,8 @@ var LIBRARY_OBJECT = (function() {
                                 var xhr = ajax_update_database('mndwi',{'xValue':this.x,'yValue':this.y,'lat':lat,'lon':lon});
                                 xhr.done(function(data) {
                                     if("success" in data) {
-                                        map.getLayers().item(3).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.water_mapid+"/{z}/{x}/{y}?token="+data.water_token);
+                                        map.getLayers().item(3).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.true_mapid+"/{z}/{x}/{y}?token="+data.true_token);
+                                        map.getLayers().item(4).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.water_mapid+"/{z}/{x}/{y}?token="+data.water_token);
                                         $("#meta-table").append('<tbody><tr><th>Latitude</th><td>'+(parseFloat(lat).toFixed(6))+'</td></tr><tr><th>Longitude</th><td>'+(parseFloat(lon).toFixed(6))+'</td></tr><tr><th>Current Date</th><td>'+data.date+'</td></tr><tr><th>Scene Cloud Cover</th><td>'+data.cloud_cover+'</td></tr></tbody>');
                                         $("#reset").removeClass('hidden');
                                         $("#layers_checkbox").removeClass('hidden');
@@ -361,7 +371,8 @@ var LIBRARY_OBJECT = (function() {
                               var xhr = ajax_update_database('mndwi',{'xValue':this.x,'yValue':this.y,'lat':lat,'lon':lon});
                               xhr.done(function(data) {
                                   if("success" in data) {
-                                      map.getLayers().item(3).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.water_mapid+"/{z}/{x}/{y}?token="+data.water_token);
+                                      map.getLayers().item(3).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.true_mapid+"/{z}/{x}/{y}?token="+data.true_token);
+                                      map.getLayers().item(4).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.water_mapid+"/{z}/{x}/{y}?token="+data.water_token);
                                       $("#meta-table").append('<tbody><tr><th>Latitude</th><td>'+(parseFloat(lat).toFixed(6))+'</td></tr><tr><th>Longitude</th><td>'+(parseFloat(lon).toFixed(6))+'</td></tr><tr><th>Current Date</th><td>'+data.date+'</td></tr><tr><th>Scene Cloud Cover</th><td>'+data.cloud_cover+'</td></tr></tbody>');
                                       $("#reset").removeClass('hidden');
                                       $("#layers_checkbox").removeClass('hidden');
@@ -446,12 +457,21 @@ var LIBRARY_OBJECT = (function() {
         $(".alert").click(function(){
             $(".alert").alert("close");
         });
-        $('#mndwi_toggle').change(function() {
+        $('#true_toggle').change(function() {
             // this will contain a reference to the checkbox
             if (this.checked) {
                 map.getLayers().item(3).setVisible(true);
             } else {
                 map.getLayers().item(3).setVisible(false);
+            }
+        });
+
+        $('#mndwi_toggle').change(function() {
+            // this will contain a reference to the checkbox
+            if (this.checked) {
+                map.getLayers().item(4).setVisible(true);
+            } else {
+                map.getLayers().item(4).setVisible(false);
             }
         });
 

--- a/tethysapp/waterwatch/public/js/map.js
+++ b/tethysapp/waterwatch/public/js/map.js
@@ -298,8 +298,8 @@ var LIBRARY_OBJECT = (function() {
                                 var xhr = ajax_update_database('mndwi',{'xValue':this.x,'yValue':this.y,'lat':lat,'lon':lon});
                                 xhr.done(function(data) {
                                     if("success" in data) {
-                                        map.getLayers().item(3).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.true_mapid+"/{z}/{x}/{y}?token="+data.true_token);
-                                        map.getLayers().item(4).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.water_mapid+"/{z}/{x}/{y}?token="+data.water_token);
+                                        map.getLayers().item(3).getSource().setUrl(data.true_mapurl);
+                                        map.getLayers().item(4).getSource().setUrl(data.water_mapurl);
                                         $("#meta-table").append('<tbody><tr><th>Latitude</th><td>'+(parseFloat(lat).toFixed(6))+'</td></tr><tr><th>Longitude</th><td>'+(parseFloat(lon).toFixed(6))+'</td></tr><tr><th>Current Date</th><td>'+data.date+'</td></tr><tr><th>Scene Cloud Cover</th><td>'+data.cloud_cover+'</td></tr></tbody>');
                                         $("#reset").removeClass('hidden');
                                         $("#layers_checkbox").removeClass('hidden');
@@ -373,8 +373,8 @@ var LIBRARY_OBJECT = (function() {
                               var xhr = ajax_update_database('mndwi',{'xValue':this.x,'yValue':this.y,'lat':lat,'lon':lon});
                               xhr.done(function(data) {
                                   if("success" in data) {
-                                      map.getLayers().item(3).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.true_mapid+"/{z}/{x}/{y}?token="+data.true_token);
-                                      map.getLayers().item(4).getSource().setUrl("https://earthengine.googleapis.com/map/"+data.water_mapid+"/{z}/{x}/{y}?token="+data.water_token);
+                                      map.getLayers().item(3).getSource().setUrl(data.true_mapurl);
+                                      map.getLayers().item(4).getSource().setUrl(data.water_mapurl);
                                       $("#meta-table").append('<tbody><tr><th>Latitude</th><td>'+(parseFloat(lat).toFixed(6))+'</td></tr><tr><th>Longitude</th><td>'+(parseFloat(lon).toFixed(6))+'</td></tr><tr><th>Current Date</th><td>'+data.date+'</td></tr><tr><th>Scene Cloud Cover</th><td>'+data.cloud_cover+'</td></tr></tbody>');
                                       $("#reset").removeClass('hidden');
                                       $("#layers_checkbox").removeClass('hidden');

--- a/tethysapp/waterwatch/public/js/map.js
+++ b/tethysapp/waterwatch/public/js/map.js
@@ -21,6 +21,7 @@ var LIBRARY_OBJECT = (function() {
         current_layer,
         layers,
         map,
+	ponds_mapurl,
         ponds_mapid,
         ponds_token,
         public_interface,				// Object returned by the module
@@ -51,8 +52,9 @@ var LIBRARY_OBJECT = (function() {
 
     init_vars = function(){
         var $layers_element = $('#layers');
-        ponds_mapid = $layers_element.attr('data-ponds-mapid');
-        ponds_token = $layers_element.attr('data-ponds-token');
+	ponds_mapurl = $layers_element.attr('data-ponds-mapurl');
+        //ponds_mapid = $layers_element.attr('data-ponds-mapid');
+        //ponds_token = $layers_element.attr('data-ponds-token');
         $chartModal = $("#chart-modal");
     };
 
@@ -103,7 +105,7 @@ var LIBRARY_OBJECT = (function() {
 
         var ponds_layer = new ol.layer.Tile({
             source: new ol.source.XYZ({
-                url: "https://earthengine.googleapis.com/map/"+ponds_mapid+"/{z}/{x}/{y}?token="+ponds_token
+                url: ponds_mapurl //"https://earthengine.googleapis.com/map/"+ponds_mapid+"/{z}/{x}/{y}?token="+ponds_token
             })
         });
 

--- a/tethysapp/waterwatch/templates/waterwatch/home.html
+++ b/tethysapp/waterwatch/templates/waterwatch/home.html
@@ -194,6 +194,7 @@
                     </table>
                     <div id="info" class="hidden info"></div>
                     <div id="layers_checkbox" class="checkbox hidden">
+                        <label><input type="checkbox" id="true_toggle" name="true_toggle" checked>Natural-color Layer</label>&nbsp
                         <label><input type="checkbox" id="mndwi_toggle" name="mndwi_toggle" checked>MNDWI Layer</label>&nbsp
                         <label><input type="checkbox" id="ponds_toggle" name="ponds_toggle" checked>Ponds Layer</label>
                     </div>

--- a/tethysapp/waterwatch/templates/waterwatch/home.html
+++ b/tethysapp/waterwatch/templates/waterwatch/home.html
@@ -5,7 +5,7 @@
 {% block styles %}
 {{ block.super }}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-<link rel="stylesheet" href="https://openlayers.org/en/v4.3.4/css/ol.css" type="text/css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/openlayers/4.6.5/ol.css" type="text/css">
 {% endblock %}
 
 {% block global_scripts %}
@@ -19,7 +19,7 @@
 <!--<script src="https://code.highcharts.com/stock/modules/exporting.js"></script>-->
 <!--<script src="http://code.highcharts.com/modules/exporting.js"></script>-->
 <!--<script src="http://highcharts.github.io/export-csv/export-csv.js"></script>-->
-<script src="https://openlayers.org/en/v4.3.4/build/ol.js" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/openlayers/4.6.5/ol.js" type="text/javascript"></script>
 {% endblock %}
 
 
@@ -106,7 +106,7 @@
 
 
 
-<div id="layers" name="layers" data-ponds-mapid="{{ponds_mapid}}" data-ponds-token="{{ponds_token}}" style="display:none;">
+<div id="layers" name="layers" data-ponds-mapurl="{{ponds_mapurl}}" style="display:none;">
     {% endblock %}
 
     {# Use the after_app_content block for modals #}

--- a/tethysapp/waterwatch/utilities.py
+++ b/tethysapp/waterwatch/utilities.py
@@ -5,16 +5,14 @@ import json
 import math
 import random
 import datetime,time
+from . import config
 
 try:
     ee.Initialize()
 except EEException as e:
-    from oauth2client.service_account import ServiceAccountCredentials
-    credentials = ServiceAccountCredentials.from_p12_keyfile(
-    service_account_email='',
-    filename='',
-    private_key_password='notasecret',
-    scopes=ee.oauth.SCOPE + ' https://www.googleapis.com/auth/drive ')
+    service_account=config.EE_SERVICE_ACCOUNT
+    secret_key=config.EE_SECRET_KEY
+    credentials = ee.ServiceAccountCredentials(service_account, secret_key) 
     ee.Initialize(credentials)
 
 def addArea(feature):

--- a/tethysapp/waterwatch/utilities.py
+++ b/tethysapp/waterwatch/utilities.py
@@ -3,7 +3,7 @@ from ee.ee_exception import EEException
 import requests
 import json
 import math
-import numpy as np
+import random
 import datetime,time
 
 try:
@@ -40,31 +40,122 @@ def s2CloudMask(img):
     # However, clouds are not snow.
     ndsi = img.normalizedDifference(['B3', 'B11'])
     score=score.min(rescale(ndsi, [0.8, 0.6]))
-    score = score.multiply(100).byte().lte(10).rename(['cloudMask'])
-    img = img.updateMask(score.Or(qa.lt(1024)))
-    return img.divide(10000).set("system:time_start", img.get("system:time_start"),'CLOUD_COVER',img.get('CLOUD_COVERAGE_ASSESSMENT'))
+    score = score.multiply(100).byte().lte(cloudThresh)
+    mask = score.And(qa.lt(1024)).rename(['cloudMask'])\
+                .clip(img.geometry())
+    img = img.addBands(mask)
+    return img.divide(10000).set("system:time_start", img.get("system:time_start"),
+                                 'CLOUD_COVER',img.get('CLOUD_COVERAGE_ASSESSMENT'),
+                                 'SUN_AZIMUTH',img.get('MEAN_SOLAR_AZIMUTH_ANGLE'),
+                                 'SUN_ZENITH',img.get('MEAN_SOLAR_ZENITH_ANGLE'),
+                                 'scale',ee.Number(10))
 
 
 def lsCloudMask(img):
     blank = ee.Image(0)
     scored = ee.Algorithms.Landsat.simpleCloudScore(img)
-    clouds = blank.where(scored.select(['cloud']).lte(cloudThresh), 1)
-    return img.updateMask(clouds).set("system:time_start", img.get("system:time_start"))
+    clouds = blank.where(scored.select(['cloud']).lte(cloudThresh), 1)\
+                .clip(img.geometry())
+    img = img.addBands(clouds.rename(['cloudMask']))
+    return img.updateMask(clouds).set("system:time_start", img.get("system:time_start"),
+                   "SUN_ZENITH",ee.Number(90).subtract(img.get('SUN_ELEVATION')),
+                   "scale",ee.Number(30))
+
+
+def simpleTDOM2(collection, zScoreThresh, shadowSumThresh, dilatePixels):
+    def darkMask(img):
+        zScore = img.select(shadowSumBands).subtract(irMean).divide(irStdDev)
+        irSum = img.select(shadowSumBands).reduce(ee.Reducer.sum())
+        TDOMMask = zScore.lt(zScoreThresh).reduce(ee.Reducer.sum()).eq(2).And(irSum.lt(shadowSumThresh)).Not()
+        TDOMMask = TDOMMask.focal_min(dilatePixels)
+        img = img.addBands(TDOMMask.rename(['TDOMMask']))
+        # Combine the cloud and shadow masks
+        combinedMask = img.select('cloudMask').mask().And(img.select('TDOMMask'))\
+            .rename('cloudShadowMask');
+        return img.addBands(combinedMask).updateMask(combinedMask)
+
+    shadowSumBands = ['nir','swir1','swir2']
+    irStdDev = collection.select(shadowSumBands).reduce(ee.Reducer.stdDev())
+    irMean = collection.select(shadowSumBands).mean()
+
+    collection = collection.map(darkMask)
+
+    return collection
 
 
 def lsTOA(img):
     return ee.Algorithms.Landsat.TOA(img)
 
+# Function for wrapping cloud and shadow masking together.
+# Assumes image has cloud mask band called "cloudMask" and a TDOM mask called "TDOMMask".
+def cloudProject(img):
+
+    azimuthField = 'SUN_AZIMUTH'
+    zenithField = 'SUN_ZENITH'
+
+    def projectHeights(cloudHeight):
+      cloudHeight = ee.Number(cloudHeight);
+      shadowCastedDistance = zenR.tan().multiply(cloudHeight); #Distance shadow is cast
+      x = azR.cos().multiply(shadowCastedDistance).divide(nominalScale).round(); #X distance of shadow
+      y = azR.sin().multiply(shadowCastedDistance).divide(nominalScale).round(); #Y distance of shadow
+      return cloud.changeProj(proj, proj.translate(x, y));
+
+    # Get the cloud mask
+    cloud = img.select(['cloudMask']).Not();
+    cloud = cloud.focal_max(dilatePixels);
+    cloud = cloud.updateMask(cloud);
+
+    # Get TDOM mask
+    TDOMMask = img.select(['TDOMMask']).Not();
+
+    # Project the shadow finding pixels inside the TDOM mask that are dark and
+    # inside the expected area given the solar geometry
+    # Find dark pixels
+    darkPixels = img.select(['nir','swir1','swir2'])\
+      .reduce(ee.Reducer.sum()).lt(shadowSumThresh);#.gte(1);
+
+    proj = img.select('cloudMask').projection()
+
+    # Get scale of image
+    nominalScale = proj.nominalScale();
+
+    #Find where cloud shadows should be based on solar geometry
+    #Convert to radians
+    meanAzimuth = img.get(azimuthField);
+    meanZenith = img.get(zenithField);
+    azR = ee.Number(meanAzimuth).multiply(math.pi).divide(180.0)\
+      .add(ee.Number(0.5).multiply(math.pi));
+    zenR = ee.Number(0.5).multiply(math.pi)\
+      .subtract(ee.Number(meanZenith).multiply(math.pi).divide(180.0));
+
+    # Find the shadows
+    shadows = cloudHeights.map(projectHeights);
+
+    shadow = ee.ImageCollection.fromImages(shadows).max();
+
+    # Create shadow mask
+    shadow = shadow.updateMask(cloud.mask().Not());
+    shadow = shadow.focal_max(dilatePixels);
+    shadow = shadow.updateMask(darkPixels.And(TDOMMask));
+
+    # Combine the cloud and shadow masks
+    combinedMask = cloud.mask().Or(shadow.mask()).eq(0);
+
+    # Update the image's mask and return the image
+    img = img.updateMask(combinedMask);
+    img = img.addBands(combinedMask.rename(['cloudShadowMask']));
+    return img.clip(img.geometry());
+
 
 def mergeCollections(l8, s2, studyArea, t1, t2):
     lc8rename = l8.filterBounds(studyArea).filterDate(t1, t2).map(lsTOA).filter(
-        ee.Filter.lt('CLOUD_COVER', 75)).map(lsCloudMask).select(['B2', 'B3', 'B4', 'B5', 'B6', 'B7'],
-                                                                 ['blue', 'green', 'red', 'nir', 'swir1', 'swir2'])
+        ee.Filter.lt('CLOUD_COVER', 75)).map(lsCloudMask).select(['B2', 'B3', 'B4', 'B5', 'B6', 'B7','cloudMask'],
+                                                                 ['blue', 'green', 'red', 'nir', 'swir1', 'swir2','cloudMask'])
 
     st2rename = s2.filterBounds(studyArea).filterDate(t1, t2).filter(
         ee.Filter.lt('CLOUD_COVERAGE_ASSESSMENT', 75)).map(s2CloudMask).select(
-        ['B2', 'B3', 'B4', 'B8', 'B11', 'B12'],
-        ['blue', 'green', 'red', 'nir', 'swir1', 'swir2'])#.map(bandPassAdjustment)
+        ['B2', 'B3', 'B4', 'B8', 'B11', 'B12','cloudMask'],
+        ['blue', 'green', 'red', 'nir', 'swir1', 'swir2','cloudMask'])#.map(bandPassAdjustment)
 
     return ee.ImageCollection(lc8rename.merge(st2rename))
 
@@ -87,24 +178,6 @@ def bandPassAdjustment(img):
     return componentsImage.set('system:time_start',img.get('system:time_start'))
 
 
-def simpleTDOM2(collection, zScoreThresh, shadowSumThresh, dilatePixels):
-    def darkMask(img):
-        zScore = img.select(shadowSumBands).subtract(irMean).divide(irStdDev)
-        irSum = img.select(shadowSumBands).reduce(ee.Reducer.sum())
-        TDOMMask = zScore.lt(zScoreThresh).reduce(ee.Reducer.sum()).eq(2).And(irSum.lt(shadowSumThresh)).Not()
-        TDOMMask = TDOMMask.focal_min(dilatePixels)
-        return img.addBands(TDOMMask.rename(['TDOMMask']))
-
-    shadowSumBands = ['nir', 'swir1']
-    irStdDev = collection.select(shadowSumBands).reduce(ee.Reducer.stdDev())
-    irMean = collection.select(shadowSumBands).mean()
-    collection.select(shadowSumBands).mean()
-
-    collection = collection.map(darkMask)
-
-    return collection
-
-
 def calcWaterIndex(img):
     mndwi = img.expression('0.1511*B1 + 0.1973*B2 + 0.3283*B3 + 0.3407*B4 + -0.7117*B5 + -0.4559*B7',{
         'B1': img.select('blue'),
@@ -115,22 +188,26 @@ def calcWaterIndex(img):
         'B7': img.select('swir2'),
     }).rename('mndwi')
 
-    return mndwi.copyProperties(img, ["system:time_start","CLOUD_COVER"])
+    return mndwi.addBands(img.select('cloudShadowMask')).copyProperties(img, ["system:time_start","CLOUD_COVER"])
 
 
 def waterClassifier(img):
     THRESHOLD = ee.Number(-0.1304)
 
-    mask = img.mask()
-
-    water = ee.Image(0).where(mask, img.select('mndwi').gt(THRESHOLD))
+    water = ee.Image(0).where(img.select('cloudShadowMask'), img.select('mndwi').gt(THRESHOLD))
 
     result = img.addBands(water.rename(['water']))
     return result.copyProperties(img, ["system:time_start","CLOUD_COVER"])
 
 
 def pondClassifier(shape):
-    latest = ee.Image(waterCollection.select('water').filterBounds(shape.geometry()).first())
+    waterList = waterCollection.filterBounds(shape.geometry())\
+                .sort('system:time_start',False)
+    latest = ee.Image(waterList.first())
+    # dates = ee.Array(waterCollection.aggregate_array('system:time_start'))
+
+    # true = ee.Image(ee.Algorithms.If(latest.geometry().contains(shape.geometry),latest,
+    #         waterList.get(1)))
 
     avg = latest.reduceRegion(
         reducer=ee.Reducer.mean(),
@@ -141,25 +218,32 @@ def pondClassifier(shape):
 
     try:
         val = ee.Number(avg.get('water'))
+        mVal = ee.Number(avg.get('cloudShadowMask'))
 
-        cls = val.gt(0.25)
+        test = ee.Number(ee.Algorithms.If(mVal.lt(0.5),ee.Number(3),ee.Number(0)))
+        cls = test.add(val.gt(0.25))
 
         cls = cls.add(val.gt(0.75))
     except:
-        val = np.random.choice(2, 1)
-        cls = ee.Number(val[0])
+        val = random.choice(range(2))
+        cls = ee.Number(val)
 
     return ee.Feature(shape).set({'pondCls': cls.int8()})
 
-def makeTimeSeries(collection,feature,key=None):
+def makeTimeSeries(collection,feature,key=None,hasMask=False):
 
     def reducerMapping(img):
+        if hasMask:
+            img = img.updateMask(img.select('cloudShadowMask'))
+
         reduction = img.reduceRegion(
             ee.Reducer.mean(), feature.geometry(), 10)
 
+        outVal = ee.Number(reduction.get(key))
+
         time = img.get('system:time_start')
 
-        return img.set('indexVal',[ee.Number(time),reduction.get(key)])
+        return img.set('indexVal',[ee.Number(time),outVal])
 
     collection = collection.filterBounds(feature.geometry()) #.getInfo()
 
@@ -167,9 +251,9 @@ def makeTimeSeries(collection,feature,key=None):
 
     indexSeries = indexCollection.aggregate_array('indexVal').getInfo()
 
-    formattedSeries = [[x[0],round(float(x[1]),3)] for x in indexSeries]
+    formattedSeries = [[x[0],round(float(x[1]),3)] for x in indexSeries if x[1] > 0]
 
-    days_with_data = [[datetime.datetime.fromtimestamp((int(x[0]) / 1000)).strftime('%Y %B %d'),round(float(x[1]),3)] for x in indexSeries if x[1] > 0 ]
+    # days_with_data = [[datetime.datetime.fromtimestamp((int(x[0]) / 1000)).strftime('%Y %B %d'),round(float(x[1]),3)] for x in indexSeries if x[1] > 0 ]
 
     return sorted(formattedSeries)
 
@@ -177,13 +261,15 @@ def getClickedImage(xValue,yValue,feature):
 
     equalDate = ee.Date(int(xValue))
 
-    water_image = ee.Image(waterCollection.select('mndwi').filterBounds(feature.geometry()).filterDate(equalDate,equalDate.advance(1,'day')).first())
+    true_image = ee.Image(mergedCollection.filterBounds(feature.geometry()).filterDate(equalDate,equalDate.advance(7    ,'day')).first())
+    true_imageid = true_image.getMapId({'min':0.05,'max':0.50,'gamma':1.5,'bands':'swir2,nir,green'})
 
-    water_imageid = water_image.getMapId({'min':-0.3,'max':0.3,'palette':'d3d3d3,84adff,9698d1,0000cc'})
+    water_image = ee.Image(waterCollection.select('mndwi').filterBounds(feature.geometry()).filterDate(equalDate,equalDate.advance(2,'day')).first())
+    water_imageid = water_image.getMapId({'min':-0.2,'max':-0.05,'palette':'d3d3d3,84adff,9698d1,0000cc'})
 
     properties =  water_image.getInfo()['properties']
 
-    return water_imageid,properties
+    return true_imageid,water_imageid,properties
 
 def accumGFS(collection,startDate,nDays):
   if (nDays>16):
@@ -292,9 +378,10 @@ class fClass(object):
               .multiply(ee.Image(86400).divide(ee.Image(1e3))).addBands(initIap.multiply(1000))\
               .addBands(A.multiply(hInit)).addBands(A).addBands(hInit)\
               .rename(['precip','Iap','vol','area','height']).clip(studyArea)\
-              .set('system:time_start',modelDate.advance(-6,'hour').millis()).float()
+              .set('system:time_start',modelDate.advance(-12,'hour').millis()).float()
 
-        modelOut = ee.ImageCollection.fromImages(dailyPrecip.iterate(self._accumVolume,ee.List([first])))
+        modelOut = ee.List(dailyPrecip.iterate(self._accumVolume,ee.List([first]))).slice(1)
+        modelOut = ee.ImageCollection.fromImages(modelOut)
 
         pondPct = modelOut.select('area').map(self._pctArea)
 
@@ -352,14 +439,15 @@ today = time.strftime("%Y-%m-%d")
 iniTime = ee.Date('2015-01-01')
 endTime = ee.Date(today)
 
-dilatePixels = 2
-zScoreThresh = -0.75
-shadowSumThresh = 0.35
-cloudThresh = 5
+dilatePixels = 2;
+cloudHeights = ee.List.sequence(200,5000,500);
+zScoreThresh = -0.8;
+shadowSumThresh = 0.35;
+cloudThresh = 10
 
 mergedCollection = mergeCollections(lc8, st2, studyArea, iniTime, endTime).sort('system:time_start', False)
 
-mergedCollection = simpleTDOM2(mergedCollection, zScoreThresh, shadowSumThresh, dilatePixels)
+mergedCollection = simpleTDOM2(mergedCollection, zScoreThresh, shadowSumThresh, dilatePixels)#.map(cloudProject)
 
 mndwiCollection = mergedCollection.map(calcWaterIndex)
 
@@ -367,7 +455,7 @@ waterCollection = mndwiCollection.map(waterClassifier)
 
 ponds_cls = ponds.map(pondClassifier)
 
-visParams = {'min': 0, 'max': 2, 'palette': 'red,yellow,green'}
+visParams = {'min': 0, 'max': 3, 'palette': 'red,yellow,green,gray'}
 
 pondsImg = ponds_cls.reduceToImage(properties=['pondCls'],
                                    reducer=ee.Reducer.first())
@@ -400,7 +488,7 @@ def checkFeature(lon,lat):
 
     selPond = filterPond(lon,lat)
 
-    ts_values = makeTimeSeries(waterCollection.select('water'),selPond,key='water')
+    ts_values = makeTimeSeries(waterCollection,selPond,key='water',hasMask=True)
     name = selPond.getInfo()['features'][0]['properties']['Nom']
     if len(name) < 2:
         name = ' Unnamed Pond'
@@ -427,7 +515,6 @@ def forecastFeature(lon,lat):
         name = ' Unnamed Pond'
 
     coordinates = selPond.getInfo()['features'][0]['geometry']['coordinates']
-
 
     return ts_values,coordinates,name
 


### PR DESCRIPTION
Updated the WaterWatch app to include the most recent suggested workflows for authenticating and calling map tile urls from earth engine results.

Authentication:
 - removed the authentication from pk12 file
 - added authentication through json secret key

Map tile calls:
These changes are reflected in 3 EE tiles for the app: `ponds`, `waterimg`, and `trueimg`
 - removed constructing map tile url based on `mapid` and `token`
 - changed the url generator to `map_id['tile_fetcher'].url_format` and passed the url directly to web mapping interface
